### PR TITLE
fix(crawler/fc2ppvdb): cookie check 切换到 fc2cmadb 域名并放宽关键字检测

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 
 ### 修复
 
+- **fc2ppvdb Cookie 检查修复**:基础域名已迁移至 fc2cmadb,cookie 检查不再依赖 `fc2ppvdb_session` 关键字
 - **avsex 更新修复**: 兼容 /cn/ 简体中文页面，修复 title/actor/tag/outline/extrafanart XPath 提取
 - **iqqtv 标题清理**：去除标题末尾的 `caribbeancom_番号` / `1pondo_番号` 等站点前缀，避免污染无码影片标题
 

--- a/mdcx/controllers/main_window/main_window.py
+++ b/mdcx/controllers/main_window/main_window.py
@@ -52,7 +52,12 @@ from mdcx.core.naming import NameRenderOptions, NamingTarget, render_name
 from mdcx.core.network_check import run_network_check
 from mdcx.core.nfo import write_nfo
 from mdcx.core.scraper import again_search, get_remain_list, start_new_scrape
-from mdcx.crawlers.fc2ppvdb import cookie_str_to_dict, fetch_article_info_with_warmup
+from mdcx.crawlers.fc2ppvdb import (
+    FC2CMADB_BASE_URL,
+    cookie_has_login_key,
+    cookie_str_to_dict,
+    fetch_article_info_with_warmup,
+)
 from mdcx.image import PreviewImageLoader
 from mdcx.models.enums import FileMode
 from mdcx.models.flags import Flags
@@ -360,7 +365,9 @@ class MyMAinWindow(QMainWindow):
             "                                border-radius: 1px;\n"
             '                                font: "Courier";'
         )
-        self.Ui.plainTextEdit_cookie_fc2ppvdb.setPlaceholderText("FC2 独立刮削请填写 fc2ppvdb cookie")
+        self.Ui.plainTextEdit_cookie_fc2ppvdb.setPlaceholderText(
+            "请粘贴 fc2cmadb.com 登录后的完整 Cookie（含 XSRF-TOKEN 与 session 项）"
+        )
         self.Ui.plainTextEdit_cookie_fc2ppvdb.setObjectName("plainTextEdit_cookie_fc2ppvdb")
         self.Ui.gridLayout_10.addWidget(self.Ui.plainTextEdit_cookie_fc2ppvdb, 4, 1, 1, 1)
 
@@ -3197,15 +3204,15 @@ class MyMAinWindow(QMainWindow):
             self.set_fc2ppvdb_status.emit(tips)
             return tips
 
-        if "fc2ppvdb_session" not in input_cookie:
-            tips = "❌ Cookie 无效！缺少 fc2ppvdb_session"
+        if not cookie_has_login_key(input_cookie):
+            tips = "❌ Cookie 无效！请粘贴 fc2cmadb.com 登录后的完整 cookie（含 XSRF-TOKEN 与 session 项）"
         else:
             cookies = cookie_str_to_dict(input_cookie)
             with manager.acquire_computed() as computed:
                 response, error = executor.run(
                     fetch_article_info_with_warmup(
                         computed.async_client,
-                        base_url="https://fc2ppvdb.com",
+                        base_url=FC2CMADB_BASE_URL,
                         number="3259498",
                         cookies=cookies,
                         use_proxy=manager.config.use_proxy,

--- a/mdcx/crawlers/fc2ppvdb.py
+++ b/mdcx/crawlers/fc2ppvdb.py
@@ -13,6 +13,18 @@ from .base import BaseCrawler, Context, CrawlerData, CrawlerException
 
 FC2CMADB_BASE_URL = "https://fc2cmadb.com"
 
+# Cookie 关键字段白名单：fc2cmadb (Laravel/Inertia) 常见 session/CSRF/remember cookie 名，
+# 以及旧版 fc2ppvdb 兼容。命中其一即视为 cookie 至少含登录态字段，
+# 不再硬性要求必须出现 fc2ppvdb_session。
+FC2_LOGIN_COOKIE_KEYS: tuple[str, ...] = (
+    "fc2cmadb_session",
+    "fc2ppvdb_session",
+    "laravel_session",
+    "XSRF-TOKEN",
+    "remember_web_",
+    "PHPSESSID",
+)
+
 
 def get_title(data):  # 获取标题
     return data.get("article", {}).get("title", "")
@@ -208,6 +220,14 @@ def cookie_str_to_dict(cookie_str: str) -> dict:  # cookie 转为字典
     except Exception:
         return {}
     return {key: morsel.value for key, morsel in cookie.items()}
+
+
+def cookie_has_login_key(cookie_str: str) -> bool:
+    """检查 cookie 字符串中是否包含 fc2cmadb/fc2ppvdb 常见登录态关键字段。"""
+
+    if not cookie_str:
+        return False
+    return any(key in cookie_str for key in FC2_LOGIN_COOKIE_KEYS)
 
 
 def normalize_fc2_number(number: str) -> str:


### PR DESCRIPTION
- cookie 检查 base_url 从硬编码 fc2ppvdb.com 改为 FC2CMADB_BASE_URL
- 新增 FC2_LOGIN_COOKIE_KEYS 白名单常量与 cookie_has_login_key 辅助函数， 命中 fc2cmadb_session / XSRF-TOKEN / laravel_session / remember_web_ / PHPSESSID 任一关键字段即视为有效，向后兼容旧 fc2ppvdb_session
- UI placeholder 改为提示 fc2cmadb.com 完整 cookie 与必含项
- docs/changelog.md 新增修复条目