### PR TITLE
refactor: 抽取 Emby API 共用函数到 emby_shared.py

### DIFF
--- a/mdcx/tools/emby_actor_image.py
+++ b/mdcx/tools/emby_actor_image.py
@@ -1,12 +1,10 @@
 import asyncio
-import base64
 import os
 import re
 import time
-import traceback
 from pathlib import Path
 from typing import Literal, cast
-from urllib.parse import quote, urlencode
+from urllib.parse import quote
 
 import aiofiles
 import aiofiles.os
@@ -20,24 +18,14 @@ from ..models.flags import Flags
 from ..signals import signal
 from ..utils import get_used_time
 from .emby_actor_manager import _parse_graphis_html, get_gfriends_index
-
-JELLYFIN_PERSON_FIELDS = ("Overview", "ProviderIds", "ProductionLocations", "Taglines", "Genres", "Tags")
-
-
-def _is_jellyfin_server() -> bool:
-    # server_type 配置为 Literal["emby", "ln"]，UI 用 "ln" 表示 Jellyfin
-    return manager.config.server_type != "emby"
-
-
-def _build_jellyfin_headers(headers: dict[str, str] | None = None) -> dict[str, str]:
-    request_headers = dict(headers or {})
-    request_headers["Authorization"] = f'MediaBrowser Token="{manager.config.api_key}"'
-    return request_headers
-
-
-def _append_query(url: str, params: dict[str, str | None]) -> str:
-    query = urlencode({key: value for key, value in params.items() if value not in ("", None)})
-    return f"{url}?{query}" if query else url
+from .emby_shared import (
+    JELLYFIN_PERSON_FIELDS,
+    _append_query,
+    _build_jellyfin_headers,
+    _generate_server_url,
+    _is_jellyfin_server,
+    _upload_actor_photo,
+)
 
 
 class ActorPhotoTaskStopped(Exception): ...
@@ -133,46 +121,6 @@ async def _get_emby_actor_list() -> list[dict]:
     if not actor_list:
         signal.show_log_text("================================================================================")
     return actor_list
-
-
-async def _upload_actor_photo(url: str, pic_path: Path) -> tuple[bool, str]:
-    try:
-        async with aiofiles.open(pic_path, "rb") as f:
-            content = await f.read()
-        # Emby/Jellyfin 头像上传接口都要求使用 base64 编码后的图片内容。
-        content = base64.b64encode(content)
-        header = {"Content-Type": "image/jpeg" if pic_path.suffix.lower() in (".jpg", ".jpeg") else "image/png"}
-        header = _build_jellyfin_headers(header)
-        async with manager.acquire_computed() as computed:
-            r, err = await computed.async_client.post_content(url=url, data=content, headers=header, use_proxy=False)
-        return r is not None, err
-    except Exception as e:
-        signal.show_log_text(traceback.format_exc())
-        return False, f"上传头像失败: {url} {pic_path} {e!s}"
-
-
-def _generate_server_url(actor_js: dict) -> tuple[str, str, str, str, str, str]:
-    server_type = manager.config.server_type
-    emby_url = str(manager.config.emby_url).rstrip("/")
-    actor_name = quote(actor_js["Name"], safe="")
-    actor_id = actor_js["Id"]
-    server_id = actor_js.get("ServerId", "")
-
-    if "emby" == server_type:
-        actor_homepage = f"{emby_url}/web/index.html#!/item?id={actor_id}&serverId={server_id}"
-        actor_person = f"{emby_url}/emby/Persons/{actor_name}"
-        pic_url = f"{emby_url}/emby/Items/{actor_id}/Images/Primary"
-        backdrop_url = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop"
-        backdrop_url_0 = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop/0"
-        update_url = f"{emby_url}/emby/Items/{actor_id}"
-    else:
-        actor_homepage = f"{emby_url}/web/index.html#!/details?id={actor_id}&serverId={server_id}"
-        actor_person = _append_query(f"{emby_url}/Persons/{actor_name}", {"userId": manager.config.user_id})
-        pic_url = f"{emby_url}/Items/{actor_id}/Images/Primary"
-        backdrop_url = f"{emby_url}/Items/{actor_id}/Images/Backdrop"
-        backdrop_url_0 = f"{emby_url}/Items/{actor_id}/Images/Backdrop/0"
-        update_url = f"{emby_url}/Items/{actor_id}"
-    return actor_homepage, actor_person, pic_url, backdrop_url, backdrop_url_0, update_url
 
 
 async def _get_gfriends_actor_data() -> dict[str, str] | Literal[False]:

--- a/mdcx/tools/emby_actor_info.py
+++ b/mdcx/tools/emby_actor_info.py
@@ -25,15 +25,13 @@ from ..signals import signal
 from ..utils import get_used_time
 from ..utils.file import copy_file_async
 from .emby_actor_image import (
-    _build_jellyfin_headers,
-    _generate_server_url,
     _get_actor_detail,
     _get_emby_actor_list,
     _get_gfriends_actor_data,
-    _is_jellyfin_server,
     update_emby_actor_photo,
 )
 from .emby_actor_manager import fill_actor_info_from_sources
+from .emby_shared import _build_jellyfin_headers, _generate_server_url, _is_jellyfin_server
 from .minnano_crawler import load_cache
 
 

--- a/mdcx/tools/emby_actor_manager.py
+++ b/mdcx/tools/emby_actor_manager.py
@@ -22,6 +22,13 @@ from ..signals import signal
 from ..utils import executor
 from ..utils.file import write_file_atomic_async
 from .actress_db import ActressDB
+from .emby_shared import (
+    _append_query,
+    _build_jellyfin_headers,
+    _generate_server_url,
+    _is_jellyfin_server,
+    _upload_actor_photo,
+)
 from .minnano_crawler import get_minnano_info
 from .wiki import get_detail, search_wiki
 
@@ -105,49 +112,6 @@ class ActorInfo:
         if not self.has_image and not self.has_overview:
             return "❌"
         return "⚠️"
-
-
-def _build_jellyfin_headers(headers: dict[str, str] | None = None) -> dict[str, str]:
-    request_headers = dict(headers or {})
-    request_headers["Authorization"] = f'MediaBrowser Token="{manager.config.api_key}"'
-    return request_headers
-
-
-def _append_query(url: str, params: dict[str, str | None]) -> str:
-    from urllib.parse import urlencode
-
-    query = urlencode({k: v for k, v in params.items() if v not in ("", None)})
-    return f"{url}?{query}" if query else url
-
-
-def _is_jellyfin_server() -> bool:
-    # server_type 配置为 Literal["emby", "ln"]，UI 用 "ln" 表示 Jellyfin
-    return manager.config.server_type != "emby"
-
-
-def _generate_server_url(actor: dict) -> tuple[str, str, str, str, str, str]:
-    server_type = manager.config.server_type
-    emby_url = str(manager.config.emby_url).rstrip("/")
-    from urllib.parse import quote
-
-    actor_name = quote(actor["Name"], safe="")
-    actor_id = actor["Id"]
-    server_id = actor.get("ServerId", "")
-    if "emby" == server_type:
-        actor_homepage = f"{emby_url}/web/index.html#!/item?id={actor_id}&serverId={server_id}"
-        actor_person = f"{emby_url}/emby/Persons/{actor_name}"
-        pic_url = f"{emby_url}/emby/Items/{actor_id}/Images/Primary"
-        backdrop_url = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop"
-        backdrop_url_0 = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop/0"
-        update_url = f"{emby_url}/emby/Items/{actor_id}"
-    else:
-        actor_homepage = f"{emby_url}/web/index.html#!/details?id={actor_id}&serverId={server_id}"
-        actor_person = _append_query(f"{emby_url}/Persons/{actor_name}", {"userId": manager.config.user_id})
-        pic_url = f"{emby_url}/Items/{actor_id}/Images/Primary"
-        backdrop_url = f"{emby_url}/Items/{actor_id}/Images/Backdrop"
-        backdrop_url_0 = f"{emby_url}/Items/{actor_id}/Images/Backdrop/0"
-        update_url = f"{emby_url}/Items/{actor_id}"
-    return actor_homepage, actor_person, pic_url, backdrop_url, backdrop_url_0, update_url
 
 
 async def get_emby_actor_list(filter_actor_only: bool = True) -> list[dict]:
@@ -506,7 +470,6 @@ async def upload_actor_image(actor: ActorInfo, image_path: str | Path) -> tuple[
     img_path = Path(image_path)
     if not img_path.exists():
         return False, f"❌ 图片文件不存在: {image_path}"
-    from .emby_actor_image import _upload_actor_photo
 
     ok, err = await _upload_actor_photo(pic_url, img_path)
     if ok:
@@ -561,7 +524,6 @@ async def upload_actor_backdrop(actor: ActorInfo, image_path: str | Path) -> tup
     img_path = Path(image_path)
     if not img_path.exists():
         return False, f"❌ 背景图片文件不存在: {image_path}"
-    from .emby_actor_image import _upload_actor_photo
 
     ok, err = await _upload_actor_photo(backdrop_url, img_path)
     if ok:

--- a/mdcx/tools/emby_actor_manager.py
+++ b/mdcx/tools/emby_actor_manager.py
@@ -22,7 +22,7 @@ from ..signals import signal
 from ..utils import executor
 from ..utils.file import write_file_atomic_async
 from .actress_db import ActressDB
-from .emby_shared import (
+from .emby_shared import (  # noqa: F401
     _append_query,
     _build_jellyfin_headers,
     _generate_server_url,

--- a/mdcx/tools/emby_actor_manager_ui.py
+++ b/mdcx/tools/emby_actor_manager_ui.py
@@ -1424,7 +1424,7 @@ class ActorDetailDialog(QDialog):
             self.log(f"🔶 加载现有头像失败: {traceback.format_exc()}")
 
     async def _download_existing_avatar(self):
-        from .emby_actor_manager import _build_jellyfin_headers, _generate_server_url
+        from .emby_shared import _build_jellyfin_headers, _generate_server_url
 
         _, _, pic_url, _, _, _ = _generate_server_url(
             {"Name": self.actor.name, "Id": self.actor.actor_id, "ServerId": self.actor.server_id}

--- a/mdcx/tools/emby_shared.py
+++ b/mdcx/tools/emby_shared.py
@@ -1,0 +1,80 @@
+"""Emby/Jellyfin API 共用工具函数。
+
+供内置补全 (emby_actor_info/emby_actor_image) 和管理器工具 (emby_actor_manager) 共用。
+"""
+
+from __future__ import annotations
+
+import base64
+import traceback
+from pathlib import Path
+from urllib.parse import quote, urlencode
+
+import aiofiles
+
+from ..config.manager import manager
+from ..signals import signal
+
+JELLYFIN_PERSON_FIELDS = (
+    "Overview",
+    "ProviderIds",
+    "ProductionLocations",
+    "Taglines",
+    "Genres",
+    "Tags",
+)
+
+
+def _is_jellyfin_server() -> bool:
+    # server_type 配置为 Literal["emby", "ln"]，UI 用 "ln" 表示 Jellyfin
+    return manager.config.server_type != "emby"
+
+
+def _build_jellyfin_headers(headers: dict[str, str] | None = None) -> dict[str, str]:
+    request_headers = dict(headers or {})
+    request_headers["Authorization"] = f'MediaBrowser Token="{manager.config.api_key}"'
+    return request_headers
+
+
+def _append_query(url: str, params: dict[str, str | None]) -> str:
+    query = urlencode({k: v for k, v in params.items() if v not in ("", None)})
+    return f"{url}?{query}" if query else url
+
+
+def _generate_server_url(actor: dict) -> tuple[str, str, str, str, str, str]:
+    server_type = manager.config.server_type
+    emby_url = str(manager.config.emby_url).rstrip("/")
+    actor_name = quote(actor["Name"], safe="")
+    actor_id = actor["Id"]
+    server_id = actor.get("ServerId", "")
+
+    if "emby" == server_type:
+        actor_homepage = f"{emby_url}/web/index.html#!/item?id={actor_id}&serverId={server_id}"
+        actor_person = f"{emby_url}/emby/Persons/{actor_name}"
+        pic_url = f"{emby_url}/emby/Items/{actor_id}/Images/Primary"
+        backdrop_url = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop"
+        backdrop_url_0 = f"{emby_url}/emby/Items/{actor_id}/Images/Backdrop/0"
+        update_url = f"{emby_url}/emby/Items/{actor_id}"
+    else:
+        actor_homepage = f"{emby_url}/web/index.html#!/details?id={actor_id}&serverId={server_id}"
+        actor_person = _append_query(f"{emby_url}/Persons/{actor_name}", {"userId": manager.config.user_id})
+        pic_url = f"{emby_url}/Items/{actor_id}/Images/Primary"
+        backdrop_url = f"{emby_url}/Items/{actor_id}/Images/Backdrop"
+        backdrop_url_0 = f"{emby_url}/Items/{actor_id}/Images/Backdrop/0"
+        update_url = f"{emby_url}/Items/{actor_id}"
+    return actor_homepage, actor_person, pic_url, backdrop_url, backdrop_url_0, update_url
+
+
+async def _upload_actor_photo(url: str, pic_path: Path) -> tuple[bool, str]:
+    try:
+        async with aiofiles.open(pic_path, "rb") as f:
+            content = await f.read()
+        content = base64.b64encode(content)
+        header = {"Content-Type": "image/jpeg" if pic_path.suffix.lower() in (".jpg", ".jpeg") else "image/png"}
+        header = _build_jellyfin_headers(header)
+        async with manager.acquire_computed() as computed:
+            r, err = await computed.async_client.post_content(url=url, data=content, headers=header, use_proxy=False)
+        return r is not None, err
+    except Exception as e:
+        signal.show_log_text(traceback.format_exc())
+        return False, f"上传头像失败: {url} {pic_path} {e!s}"


### PR DESCRIPTION
将 _generate_server_url/_build_jellyfin_headers/_is_jellyfin_server/ _append_query/_upload_actor_photo 五个完全一致的函数从 emby_actor_image 和 emby_actor_manager 中提取到新建的 emby_shared 模块。

两个模块均从 emby_shared 导入并 re-export，保持向后兼容。
消除了 manager 中两处 _upload_actor_photo 的 lazy import。