### PR TITLE
perf: 本地头像预扫描索引，避免逐演员全树遍历

### DIFF
--- a/mdcx/tools/emby_actor_manager.py
+++ b/mdcx/tools/emby_actor_manager.py
@@ -610,7 +610,13 @@ async def from_minnano_image(actor: ActorInfo, cache_dir: Path) -> str | None:
     return None
 
 
-def from_local_avatar(actor: ActorInfo, local_avatar_dir: str) -> str | None:
+def from_local_avatar(
+    actor: ActorInfo,
+    local_avatar_dir: str,
+    pre_scanned_index: dict[str, str] | None = None,
+) -> str | None:
+    if pre_scanned_index is not None:
+        return pre_scanned_index.get(actor.name)
     if not local_avatar_dir:
         return None
     avatar_dir = Path(local_avatar_dir)
@@ -620,6 +626,23 @@ def from_local_avatar(actor: ActorInfo, local_avatar_dir: str) -> str | None:
         if f.is_file() and f.suffix.lower() in (".jpg", ".jpeg", ".png") and f.stem == actor.name:
             return str(f)
     return None
+
+
+def build_local_avatar_index(local_avatar_dir: str) -> dict[str, str]:
+    """扫描本地头像目录，构建 {stem: path} 索引。
+
+    供批量预览场景一次性扫描，避免逐演员全树遍历。
+    """
+    index: dict[str, str] = {}
+    if not local_avatar_dir:
+        return index
+    avatar_dir = Path(local_avatar_dir)
+    if not avatar_dir.exists():
+        return index
+    for f in avatar_dir.rglob("*"):
+        if f.is_file() and f.suffix.lower() in (".jpg", ".jpeg", ".png") and f.stem not in index:
+            index[f.stem] = str(f)
+    return index
 
 
 async def fetch_actor_info_from_source(actor: ActorInfo, source: str) -> tuple[bool, str, object]:

--- a/mdcx/tools/emby_actor_manager_ui.py
+++ b/mdcx/tools/emby_actor_manager_ui.py
@@ -39,6 +39,7 @@ from ..config.resources import resources
 from ..utils import executor
 from .emby_actor_manager import (
     ActorInfo,
+    build_local_avatar_index,
     fetch_actor_detail,
     fetch_actor_info_from_source,
     fetch_all_actors,
@@ -143,6 +144,7 @@ class PreparePreviewThread(QThread):
         self.cache_dir = resources.u("emby_actor_cache")
         self.image_sources = ["gfriends", "graphis", "minnano", "local"]
         self.local_avatar_dir = ""
+        self._local_avatar_index: dict[str, str] | None = None
         self._cancel = False
 
     def cancel(self):
@@ -172,6 +174,10 @@ class PreparePreviewThread(QThread):
 
     async def _process_all(self, need_image: bool, need_info: bool, force: bool, total: int) -> bool:
         """在单个 event loop 内并发处理所有演员，避免多线程多 loop 并发共享 async_client。"""
+        if need_image and "local" in self.image_sources and self.local_avatar_dir:
+            self.progress.emit(0, total, "扫描本地头像目录...")
+            self._local_avatar_index = await asyncio.to_thread(build_local_avatar_index, self.local_avatar_dir)
+
         sem = asyncio.Semaphore(10)
 
         async def guarded(actor: ActorInfo) -> ActorInfo:
@@ -228,7 +234,7 @@ class PreparePreviewThread(QThread):
                     actor.need_update_image = True
                     return
             elif src == "local":
-                result = from_local_avatar(actor, self.local_avatar_dir)
+                result = from_local_avatar(actor, self.local_avatar_dir, self._local_avatar_index)
                 if result:
                     actor.new_image_path = result
                     actor.need_update_image = True

--- a/tests/test_emby_actor_manager.py
+++ b/tests/test_emby_actor_manager.py
@@ -6,6 +6,7 @@ from mdcx.tools.emby_actor_manager import (
     ActorInfo,
     _build_jellyfin_headers,
     _generate_server_url,
+    build_local_avatar_index,
     delete_actor_image,
     from_local_avatar,
     gfriends_find_actor,
@@ -105,6 +106,51 @@ def test_from_local_avatar_returns_none_when_dir_not_exists(tmp_path: Path):
 def test_from_local_avatar_returns_none_when_dir_empty_string():
     actor = ActorInfo(name="三上悠亚", actor_id="id1", server_id="srv1")
     assert from_local_avatar(actor, "") is None
+
+
+def test_from_local_avatar_with_pre_scanned_index_hit(tmp_path: Path):
+    avatar_dir = tmp_path / "avatars"
+    avatar_dir.mkdir(parents=True)
+    pic = avatar_dir / "三上悠亚.jpg"
+    pic.write_text("fake", encoding="utf-8")
+
+    index = build_local_avatar_index(str(avatar_dir))
+    assert "三上悠亚" in index
+
+    actor = ActorInfo(name="三上悠亚", actor_id="id1", server_id="srv1")
+    result = from_local_avatar(actor, str(avatar_dir), pre_scanned_index=index)
+    assert result == str(pic)
+
+
+def test_from_local_avatar_with_pre_scanned_index_miss():
+    index = {"别的演员": "/some/path.jpg"}
+    actor = ActorInfo(name="三上悠亚", actor_id="id1", server_id="srv1")
+    assert from_local_avatar(actor, "/nonexistent", pre_scanned_index=index) is None
+
+
+def test_from_local_avatar_with_empty_index_returns_none():
+    actor = ActorInfo(name="三上悠亚", actor_id="id1", server_id="srv1")
+    assert from_local_avatar(actor, "/nonexistent", pre_scanned_index={}) is None
+
+
+def test_build_local_avatar_index_skips_non_image_files(tmp_path: Path):
+    avatar_dir = tmp_path / "avatars"
+    avatar_dir.mkdir(parents=True)
+    (avatar_dir / "actor1.jpg").write_text("fake", encoding="utf-8")
+    (avatar_dir / "actor2.png").write_text("fake", encoding="utf-8")
+    (avatar_dir / "readme.txt").write_text("fake", encoding="utf-8")
+    (avatar_dir / "actor1.json").write_text("{}", encoding="utf-8")
+
+    index = build_local_avatar_index(str(avatar_dir))
+    assert set(index.keys()) == {"actor1", "actor2"}
+
+
+def test_build_local_avatar_index_returns_empty_for_nonexistent_dir():
+    assert build_local_avatar_index("/nonexistent/path") == {}
+
+
+def test_build_local_avatar_index_returns_empty_for_empty_string():
+    assert build_local_avatar_index("") == {}
 
 
 def test_actor_info_status_text():


### PR DESCRIPTION
FetchPreviewThread._process_all 开头扫描一次本地头像目录，
构建 {stem: path} 索引传给 from_local_avatar 的 pre_scanned_index 参数。 N 个演员从 N 次全树扫描降为 1 次。

新增 build_local_avatar_index 工具函数和 6 个测试用例。